### PR TITLE
Fix AttributeError on handleDiscovery

### DIFF
--- a/bleah/scan.py
+++ b/bleah/scan.py
@@ -250,7 +250,7 @@ class ScanReceiver(DefaultDelegate):
             elif tag in [8, 9]:
                 try:
                     self.devdata[dev.addr][desc] = val.decode('utf-8')
-                except UnicodeEncodeError:
+                except (UnicodeEncodeError, AttributeError) as e:
                     self.devdata[dev.addr][desc] = repr(val)
             else:
                 self.devdata[dev.addr][desc] = repr(val)


### PR DESCRIPTION
During a scan some results crash with the following error:
<img width="1085" alt="Captura de Tela 2023-07-06 às 20 16 28" src="https://github.com/hackgnar/bleah/assets/29243304/5163b903-5fe8-44e6-ba88-575c00d17de0">

I've added the `AttributeError` to the exception handler, and it seems to work as expected. I didn't look too much to find why this object was a str, but I hope this helps someone with the same error.