### PR TITLE
Fix "in <string> requires string as left operand, not int"

### DIFF
--- a/bleah/enumerate.py
+++ b/bleah/enumerate.py
@@ -49,7 +49,7 @@ def is_mostly_printable(s):
     pr  = 0
 
     for c in s:
-        if c in string.printable:
+        if c in bytes(string.printable, "ascii"):
             pr += 1
 
     return ( pr / float(tot) ) >= 0.75


### PR DESCRIPTION
The function is_mostly_printable receive binary data, but was doing a `in` verification on a string. The exception caused all the values of the enumeration to get the same error message.

<img width="1436" alt="image" src="https://github.com/hackgnar/bleah/assets/29243304/b8cff39a-c55b-414c-8cb2-423f5df5af07">
